### PR TITLE
349 create a sample postback php page for adgate rewards web publishers to use as an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ You can find your wall id [here](https://panel.adgatemedia.com/affiliate/vc-wall
 ![Alt text](/Wall_Code_Example.png?raw=true "Wall code example")
 You can see our two codes here are **nQ** and **ng**
 ### Step 2: Determine how you will create your user id
-The	user	id	may	be	any	string	up	to	255	characters	long.	Although	a	simple	integer	
-representing	a	user	id	may	be	used,	we	highly	suggest	hashing	the	user	id	with	a	secret	
-salt	and	using	that	value	instead.	This	will	prevent	your	users	from	guessing	random	
+The	user	id	may	be	any	string	up	to	255	characters	long.	Although	a	simple	integer
+representing	a	user	id	may	be	used,	we	highly	suggest	hashing	the	user	id	with	a	secret
+salt	and	using	that	value	instead.	This	will	prevent	your	users	from	guessing	random
 integers	and	altering	another	users'	offer	wall. Below is an example how to do that in PHP.
 
 The following example assumes you have a user id from a database.
@@ -63,6 +63,8 @@ You will take both of the pieces of information obtained in Step 1 & 2 and creat
 It is also recommended to set the iframe height to that of the users browser. This can be done in either [CSS](http://www.tagindex.net/css/frame/width_height.html) or [inline of the iframe.](http://www.w3schools.com/tags/att_iframe_height.asp)
 
 ### Step 4: Postback Information
-You'll need to set up a URL endpoint on your server, a postback, that we will call when a user completes an offer, or we receive a chargeback for a previously completed offer. 
+You'll need to set up a URL endpoint on your server, a postback, that we will call when a user completes an offer, or we receive a chargeback for a previously completed offer.
 
 For more detailed information you can go to [your vc wall](https://panel.adgatemedia.com/affiliate/vc-walls) click "Create AdGate Reward Wall" and then click "More Information on Postbacks" located under the Postback field.
+
+For an example of a plain PHP script handling Postbacks see [Plain PHP Postback Example](postback.php).

--- a/README.md
+++ b/README.md
@@ -67,4 +67,6 @@ You'll need to set up a URL endpoint on your server, a postback, that we will ca
 
 For more detailed information you can go to [your vc wall](https://panel.adgatemedia.com/affiliate/vc-walls) click "Create AdGate Reward Wall" and then click "More Information on Postbacks" located under the Postback field.
 
-For an example of a plain PHP script handling Postbacks see [Plain PHP Postback Example](postback.php).
+For an example of a plain PHP script handling Postbacks with a PDO database connection see [Plain PHP Postback PDO Example](postback_pdo_example.php).
+
+For an example of a plain PHP script handling Postbacks with an Object see [Plain PHP Postback OO Example](postback_oo_example.php).

--- a/postback.php
+++ b/postback.php
@@ -77,7 +77,7 @@ try {
     $conn->bindValue(':user_id', $data['user_id']);
     $conn->bindValue('offer_id', $data['offer_id']);
     // use exec() because no results are returned
-    // $conn->exec();
+    $conn->exec();
     echo "New Postback recorded successfully";
 }
 catch(PDOException $e)

--- a/postback.php
+++ b/postback.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * For a plain PHP page to receive the postback data from AdGate Media you may simply
+ * retrieve the array from the global $_GET variable. To ensure that the data is coming
+ * from AdGate Media check that the server sending the data is AdGate Media at 104.130.7.162.
+ */
+define('AdGate_IP', '104.130.7.162');
+protected $ip = $_SERVER['REMOTE_ADDR'];
+protected $data = null;
+protected $servername = "localhost";
+protected $username = "username";
+protected $password = "password";
+protected $dbname = "app";
+
+
+/**
+ * Check the Remote Address is AdGate Media
+ * if it is not throw an Exception
+ */
+if($ip === AdGate_IP)
+{
+    $data = $_GET;
+    // Process or Persist Data here inline or via a function call.
+} else {
+    throw new InvalidIPException();
+}
+
+
+/**
+ * The data array will contain all the macros you included under the Postbacks section of your
+ * affiliate panel at http://adgatemedia.com. The array is keyed by the names you assigned to each macro
+ * when you constructed the url e.g., http://yoururl.com/postback/?tx_id={transaction_id}
+ * the transaction_id macro's data will have a key of 'tx_id' in the $data array: $data['tx_id'];
+ *
+ * Possible Macros
+ *   {offer_id} - ID of offer.
+ *   {offer_name} - Name of offer, url encoded
+ *   {affiliate_id} - ID of affiliate.
+ *   {source} - Source value specified in the tracking link.
+ *   {s1} - Affiliate sub specified in the tracking link.
+ *   {s2} - Affiliate sub 2 specified in the tracking link.
+ *   {s3} - Affiliate sub 3 specified in the tracking link.
+ *   {s4} - Affiliate sub 4 specified in the tracking link.
+ *   {s5} - Affiliate sub 5 specified in the tracking link.
+ *   {transaction_id} - ID of click and conversion on the network.
+ *   {session_ip} - User's IP address that started the tracking session.
+ *   {date} - Current date of conversion formatted as YYYY-MM-DD.
+ *   {time} - Current time of conversion formatted as HH:MM:SS.
+ *   {datetime} - Current date and time of conversion formatted as YYYY-MM-DD HH:MM:SS.
+ *   {ran} - Randomly generated number.
+ *   {payout} - Amount paid to affiliate for conversion. In whole dollars: xx.xx
+ *   {status} - 1 for approved conversion. 0 for charged back conversion.
+ *   {points} - Decimal, number of points/credits the user earned on your website or game
+ *   {vc_title} - Title of the campaign as it is displayed on the offer wall
+ *
+ * Parsing:
+ * From the data array you may parse the data into an object, supply it to an SQL query, or do
+ * any needed processing or persisting required by your application.
+ *
+ */
+
+/**
+ * Parse into an Object Example
+ */
+$postback = new Postback($data); // A simple data object could be a simple Collection object
+
+/**
+ * Inline SQL Query Example
+ */
+try {
+    $conn = new PDO("mysql:host=$servername;dbname=$dbname", $username, $password);
+    // set the PDO error mode to exception
+    $conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    $conn->prepare("INSERT INTO Postbacks (tx_id, user_id, offer_id) VALUES (:tx_id,:user_id. :offer_id)");
+    $conn->bindValue(':tx_id', $data['tx_id']);
+    $conn->bindValue(':user_id', $data['user_id']);
+    $conn->bindValue('offer_id', $data['offer_id']);
+    // use exec() because no results are returned
+    // $conn->exec();
+    echo "New Postback recorded successfully";
+}
+catch(PDOException $e)
+{
+    echo $sql . "<br>" . $e->getMessage();
+}
+
+$conn = null;
+
+/**
+ * Processing Example
+ * This example shows sending an notification to an admin when receiving a charge back of a conversion
+ * being sent to the postback url.
+ */
+if($data['status'] == 0)
+{
+    Notify::admin("Conversion charge back for offer " . $data['offer_id'] . " on transaction " . $data['tx_id'] . "!");
+}

--- a/postback_oo_example.php
+++ b/postback_oo_example.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * For a plain PHP page to receive the postback data from AdGate Media you may simply
+ * retrieve the array from the global $_GET variable. To ensure that the data is coming
+ * from AdGate Media check that the server sending the data is from AdGate Media by the ip
+ * address as listed on your affiliate panel at http://adgatemedia.com under
+ * the Postbacks Section and the Postback Information heading.
+ */
+define('AdGate_IP', '123.123.123.123'); // Note: as noted above change the IP to match what is in your affiliate panel.
+protected $ip = $_SERVER['REMOTE_ADDR'];
+protected $data = null;
+
+
+/**
+ * Check if the Remote Address is AdGate Media
+ * if it is not throw an Exception
+ */
+if($ip === AdGate_IP)
+{
+    $data = $_GET;
+    // Process or Persist Data here inline or via a function call.
+} else {
+    // Throw either a custom Exception or just throw a generic \Exception
+    throw new InvalidIPException();
+}
+
+
+/**
+ * The data array will contain all the macros you included under the Postbacks section of your
+ * affiliate panel at http://adgatemedia.com. The array is keyed by the names you assigned to each macro
+ * when you constructed the url e.g., http://yoururl.com/postback/?tx_id={transaction_id}
+ * the transaction_id macro's data will have a key of 'tx_id' in the $data array: $data['tx_id'];
+ *
+ * Possible Macros
+ * For a list of possible macros see your affiliate panel at http://adgatemedia.com under the
+ * Postbacks section and the heading Postback Information.
+ *
+ * Parsing:
+ * From the data array you may parse the data into an object, supply it to an SQL query, or do
+ * any needed processing or persisting required by your application.
+ *
+ */
+
+/**
+ * Parse into an Object Example
+ *
+ * You can import the Postback data into your own custom Postback object.
+ * For a simple solution you could use a Collection object to hold the Postback data,
+ * if you are using a framework consider using their supplied facilities for holding and
+ * persisting data. Refer to your frameworks documentation.
+ */
+$postback = new Postback($data);
+
+
+/**
+ * Processing Example
+ * This example shows sending an notification to an admin when receiving a charge back of a conversion
+ * being sent to the postback url.
+ *
+ * The example uses a Static Notify class, use your own notification class or one provided by your framework
+ * of choice.
+ */
+if($data['status'] == 0)
+{
+    Notify::admin("Conversion charge back for offer " . $data['offer_id'] . " on transaction " . $data['tx_id'] . "!");
+}

--- a/postback_pdo_example.php
+++ b/postback_pdo_example.php
@@ -3,9 +3,11 @@
 /**
  * For a plain PHP page to receive the postback data from AdGate Media you may simply
  * retrieve the array from the global $_GET variable. To ensure that the data is coming
- * from AdGate Media check that the server sending the data is AdGate Media at 104.130.7.162.
+ * from AdGate Media check that the server sending the data is from AdGate Media by the ip
+ * address as listed on your affiliate panel at http://adgatemedia.com under
+ * the Postbacks Section and the Postback Information heading.
  */
-define('AdGate_IP', '104.130.7.162');
+define('AdGate_IP', '123.123.123.123'); // Note: as noted above change the IP to match what is in your affiliate panel.
 protected $ip = $_SERVER['REMOTE_ADDR'];
 protected $data = null;
 protected $servername = "localhost";
@@ -23,6 +25,8 @@ if($ip === AdGate_IP)
     $data = $_GET;
     // Process or Persist Data here inline or via a function call.
 } else {
+
+     // Throw either a custom Exception or just throw a generic \Exception
     throw new InvalidIPException();
 }
 
@@ -34,25 +38,8 @@ if($ip === AdGate_IP)
  * the transaction_id macro's data will have a key of 'tx_id' in the $data array: $data['tx_id'];
  *
  * Possible Macros
- *   {offer_id} - ID of offer.
- *   {offer_name} - Name of offer, url encoded
- *   {affiliate_id} - ID of affiliate.
- *   {source} - Source value specified in the tracking link.
- *   {s1} - Affiliate sub specified in the tracking link.
- *   {s2} - Affiliate sub 2 specified in the tracking link.
- *   {s3} - Affiliate sub 3 specified in the tracking link.
- *   {s4} - Affiliate sub 4 specified in the tracking link.
- *   {s5} - Affiliate sub 5 specified in the tracking link.
- *   {transaction_id} - ID of click and conversion on the network.
- *   {session_ip} - User's IP address that started the tracking session.
- *   {date} - Current date of conversion formatted as YYYY-MM-DD.
- *   {time} - Current time of conversion formatted as HH:MM:SS.
- *   {datetime} - Current date and time of conversion formatted as YYYY-MM-DD HH:MM:SS.
- *   {ran} - Randomly generated number.
- *   {payout} - Amount paid to affiliate for conversion. In whole dollars: xx.xx
- *   {status} - 1 for approved conversion. 0 for charged back conversion.
- *   {points} - Decimal, number of points/credits the user earned on your website or game
- *   {vc_title} - Title of the campaign as it is displayed on the offer wall
+ * For a list of possible macros see your affiliate panel at http://adgatemedia.com under the
+ * Postbacks section and the heading Postback Information.
  *
  * Parsing:
  * From the data array you may parse the data into an object, supply it to an SQL query, or do
@@ -60,10 +47,6 @@ if($ip === AdGate_IP)
  *
  */
 
-/**
- * Parse into an Object Example
- */
-$postback = new Postback($data); // A simple data object could be a simple Collection object
 
 /**
  * Inline SQL Query Example
@@ -91,6 +74,9 @@ $conn = null;
  * Processing Example
  * This example shows sending an notification to an admin when receiving a charge back of a conversion
  * being sent to the postback url.
+ *
+ * The example uses a Static Notify class, use your own notification class or one provided by your framework
+ * of choice.
  */
 if($data['status'] == 0)
 {


### PR DESCRIPTION
This is the Plain PHP script example for an affiliate accepting postbacks. The example shows checking for the ip from AdGate Media, processing the postback url, and persisting it in a variety of ways. 
